### PR TITLE
Main fix delete mailing delete sarbacane campaign

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,14 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+
+
+Version 1.1 (2021-06-09)
+=====================
+- FIX delete sarbacane campaign and stats when mailing is deleting *2021-06-17* - 1.1.6
 - FIX Set blacklist_id by "DEFAULT_BLACKLIST" when it is empty *2021-06-16* - 1.1.5
 - FIX Modify module position to place it under Emailing module in perms list *2021-06-02* - 1.1.4
 - NEW (describe any new feature that is only included in the main branch but not
   yet in release branches) *2021-06-01* - 1.1.3
-- FIX Update campaign stats for the last three months only *2021-06-01* - 1.1.2 
-
-Version 1.1 (2021-06-09)
-=====================
+- FIX Update campaign stats for the last three months only *2021-06-01* - 1.1.2
 - FIX : Màj statistiques => statuts des destinataires du mailing même si il n'y a pas de destinataires de type contact - *15/06/2021* - 1.1.1
 - NEW : Ajout conf "SARBACANE_EXPORT_EMPTYLIST" qui permet de vider totalement la liste de contacts avant l'ajout lors de l'export - *09/06/2021* - 1.1
 

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -541,6 +541,32 @@ class DolSarbacane extends CommonObject {
             }
         }
 
+        //on supprime aussi la ligne liée à la campagne sarbacane dans la table sarbacane_campaign_contact
+        if(! $error && !empty($this->sarbacane_id)) {
+            $sql = "DELETE FROM ".MAIN_DB_PREFIX."sarbacane_campaign_contact";
+            $sql .= " WHERE sarbacane_campaignid='".$this->sarbacane_id."'";
+
+            dol_syslog(get_class($this)."::delete sql=".$sql);
+            $resql = $this->db->query($sql);
+            if(! $resql) {
+                $error++;
+                $this->errors[] = "Error ".$this->db->lasterror();
+            }
+        }
+
+        //on supprime aussi la ligne liée à la campagne sarbacane dans la table sarbacane_campaign_contact
+        if(! $error && !empty($this->sarbacane_id)) {
+            $sql = "DELETE FROM ".MAIN_DB_PREFIX."sarbacane_campaign_contact";
+            $sql .= " WHERE sarbacane_campaignid='".$this->sarbacane_id."'";
+
+            dol_syslog(get_class($this)."::delete sql=".$sql);
+            $resql = $this->db->query($sql);
+            if(! $resql) {
+                $error++;
+                $this->errors[] = "Error ".$this->db->lasterror();
+            }
+        }
+
         // Commit or rollback
         if($error) {
             foreach($this->errors as $errmsg) {

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -554,19 +554,6 @@ class DolSarbacane extends CommonObject {
             }
         }
 
-        //on supprime aussi la ligne liée à la campagne sarbacane dans la table sarbacane_campaign_contact
-        if(! $error && !empty($this->sarbacane_id)) {
-            $sql = "DELETE FROM ".MAIN_DB_PREFIX."sarbacane_campaign_contact";
-            $sql .= " WHERE sarbacane_campaignid='".$this->sarbacane_id."'";
-
-            dol_syslog(get_class($this)."::delete sql=".$sql);
-            $resql = $this->db->query($sql);
-            if(! $resql) {
-                $error++;
-                $this->errors[] = "Error ".$this->db->lasterror();
-            }
-        }
-
         // Commit or rollback
         if($error) {
             foreach($this->errors as $errmsg) {

--- a/contact_tab.php
+++ b/contact_tab.php
@@ -150,8 +150,8 @@ dol_fiche_end();
 $sql = "SELECT";
 $sql.= " m.titre, s.fk_mailing, scc.sarbacane_campaignid, scc.statut, scc.nb_open, scc.nb_click, scc.unsubscribe, scc.unsubscribed_email, scc.used_blacklist";
 $sql.= " FROM ".MAIN_DB_PREFIX.DolSarbacane::$campaign_contact_table." as scc";
-$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."sarbacane as s ON s.sarbacane_id = scc.sarbacane_campaignid";
-$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."mailing m ON m.rowid = s.fk_mailing";
+$sql.= " JOIN ".MAIN_DB_PREFIX."sarbacane as s ON s.sarbacane_id = scc.sarbacane_campaignid";
+$sql.= " JOIN ".MAIN_DB_PREFIX."mailing m ON m.rowid = s.fk_mailing";
 $sql.= " WHERE scc.fk_contact = ".$id;
 // Todo ajouter les filtres
 

--- a/core/modules/modsarbacane.class.php
+++ b/core/modules/modsarbacane.class.php
@@ -60,7 +60,7 @@ class modsarbacane extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module sarbacane";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.5';
+		$this->version = '1.1.6';
 		// Key used in llx_const table to save module status enabled/disabled (where SARBACANE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/core/triggers/interface_99_modsarbacane_sarbacanetrigger.class.php
+++ b/core/triggers/interface_99_modsarbacane_sarbacanetrigger.class.php
@@ -635,4 +635,30 @@ class Interfacesarbacanetrigger extends DolibarrTriggers
 
 		return 0;
 	}
+
+	/**
+	 * @param string $action
+	 * @param Contact $object
+	 * @param User $user
+	 * @param Translate $langs
+	 * @param $conf
+	 * @return int
+	 */
+    public function mailingDelete($action, $object, $user, $langs, $conf)
+	{
+		global $db, $user;
+
+		dol_include_once('sarbacane/class/dolsarbacane.class.php');
+
+		$sarbacane = new DolSarbacane($db);
+		$res = $sarbacane->fetch_by_mailing($object->id);
+
+		if($res > 0){
+			return $sarbacane->delete($user);
+		} elseif($res < 0){
+			return -1;
+		}
+
+		return 0;
+	}
 }


### PR DESCRIPTION
- Lorqu'un mailing est supprimé, le lien avec la campagne sarbacane dans dolibarr l'est aussi.
- Lorsqu'on supprime une campagne sarbacane dolibarr, alors ses stats sont supprimmées aussi 
- Il ne faut plus que la ligne de la campagne dans l'onglet "sarbacane" de la fiche contact apparaisse si le mailing a été supprimé

/!\ Ne fonctionne pas sans la PR standard qui ajout le trigger : https://github.com/Dolibarr/dolibarr/pull/17962