### PR TITLE
Main fix sgp distribution list compatibility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Version 1.1 (2021-06-09)
 =====================
+- FIX Distribution List Compatibility *2021-06-22* - 1.1.7
 - FIX delete sarbacane campaign and stats when mailing is deleting *2021-06-17* - 1.1.6
 - FIX Set blacklist_id by "DEFAULT_BLACKLIST" when it is empty *2021-06-16* - 1.1.5
 - FIX Modify module position to place it under Emailing module in perms list *2021-06-02* - 1.1.4

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -945,56 +945,41 @@ class DolSarbacane extends CommonObject {
 
             if(! empty($tmp_array[0]) && isValidEmail($tmp_array[0]) && ! in_array($tmp_array[0], $email_added)) {
 
-            	if(!empty($tmp_array[3])) {
+            	if ($tmp_array[1] == 'contact' || $tmp_array[1] == 'DistributionList') {
+            		$contactstatic = new Contact($this->db);
+            		$result = $contactstatic->fetch($tmp_array[3]);
 
-					if ($tmp_array[1] == 'contact' || $tmp_array[1] == 'DistributionList') {
-						$contactstatic = new Contact($this->db);
-						$result = $contactstatic->fetch($tmp_array[3]);
+            		if ($result < 0) {
+            			$this->error = $contactstatic->error;
+            			dol_syslog(get_class($this) . "::getListDestinaries " . $this->error, LOG_ERR);
+            			return -1;
+            		}
+            		if (!empty($contactstatic->id)) {
+            			$merge_vars->FNAME = $contactstatic->firstname;
+            			$merge_vars->LNAME = $contactstatic->lastname;
+            			$merge_vars->CIVILITY = $contactstatic->civility;
+            			$merge_vars->EMAIL = $tmp_array[0];
+            		}
+            	}
+            	if ($tmp_array[1] == 'thirdparty') {
+            		$socstatic = new Societe($this->db);
+            		$result = $socstatic->fetch($tmp_array[2]);
+            		if ($result < 0) {
+            			$this->error = $socstatic->error;
+            			dol_syslog(get_class($this) . "::getListDestinaries " . $this->error, LOG_ERR);
+            			return -1;
+            		}
+            		if (!empty($socstatic->id)) {
+            			$merge_vars->FNAME = $socstatic->name;
+            			$merge_vars->EMAIL = $tmp_array[0];
+            		}
+            	}
 
-						if ($result < 0) {
-							$this->error = $contactstatic->error;
-							dol_syslog(get_class($this) . "::getListDestinaries " . $this->error, LOG_ERR);
-							return -1;
-						}
-						if (!empty($contactstatic->id)) {
-							$merge_vars->FNAME = $contactstatic->firstname;
-							$merge_vars->LNAME = $contactstatic->lastname;
-							$merge_vars->CIVILITY = $contactstatic->civility;
-							$merge_vars->EMAIL = $tmp_array[0];
-						}
-					}
-					if ($tmp_array[1] == 'thirdparty') {
-						$socstatic = new Societe($this->db);
-						$result = $socstatic->fetch($tmp_array[2]);
-						if ($result < 0) {
-							$this->error = $socstatic->error;
-							dol_syslog(get_class($this) . "::getListDestinaries " . $this->error, LOG_ERR);
-							return -1;
-						}
-						if (!empty($socstatic->id)) {
-							$merge_vars->FNAME = $socstatic->name;
-							$merge_vars->EMAIL = $tmp_array[0];
-						}
-					}
-				} else {
+            	if($tmp_array[1] == 'file'){
             		if(!empty($tmp_array[5])) $merge_vars->FNAME = $tmp_array[5];
 					if(!empty($tmp_array[4])) $merge_vars->LNAME = $tmp_array[4];
 					if(!empty($tmp_array[0])) $merge_vars->EMAIL = $tmp_array[0];
 				}
-
-
-                if($tmp_array[1] == 'file') {
-
-                    if($result < 0) {
-                        $this->error = $socstatic->error;
-                        dol_syslog(get_class($this)."::getListDestinaries ".$this->error, LOG_ERR);
-                        return -1;
-                    }
-                    if(! empty($socstatic->id)) {
-                        $merge_vars->FNAME = $socstatic->name;
-                        $merge_vars->EMAIL = $tmp_array[0];
-                    }
-                }
 
                 dol_syslog(get_class($this)."::addEmailToList listid=".$listid." merge_vars=".var_export($merge_vars, true).' $tmp_array[0]='.$tmp_array[0], LOG_DEBUG);
 
@@ -1027,7 +1012,7 @@ class DolSarbacane extends CommonObject {
                         "email" => $email['email_address'],
                         "phone" => ""
                     );
-                    if($tmp_array[1] == 'contact' || $tmp_array[1] == 'DistributionList') {
+                    if($email['tmp_array'][1] == 'contact' || $email['tmp_array'][1] == 'DistributionList' || $email['tmp_array'][1] == 'file') {
                         $found = 0;
 
                         $civ_id = 'CIVILITY_ID';

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -1230,9 +1230,10 @@ class DolSarbacane extends CommonObject {
      */
     public function getContactDolibarrIdByMail ($email) {
         if(!empty($this->email_lines)){
-            foreach($this->email_lines as $email_line) {
+        	foreach($this->email_lines as $email_line) {
                 $tmp_array = explode('&', $email_line);
                 if($tmp_array[0] == $email && $tmp_array[1] == 'contact') return $tmp_array[2];
+                if($tmp_array[0] == $email && $tmp_array[1] == 'DistributionList') return $tmp_array[3];
             }
         }
 

--- a/contact_tab.php
+++ b/contact_tab.php
@@ -150,8 +150,8 @@ dol_fiche_end();
 $sql = "SELECT";
 $sql.= " m.titre, s.fk_mailing, scc.sarbacane_campaignid, scc.statut, scc.nb_open, scc.nb_click, scc.unsubscribe, scc.unsubscribed_email, scc.used_blacklist";
 $sql.= " FROM ".MAIN_DB_PREFIX.DolSarbacane::$campaign_contact_table." as scc";
-$sql.= " JOIN ".MAIN_DB_PREFIX."sarbacane as s ON s.sarbacane_id = scc.sarbacane_campaignid";
-$sql.= " JOIN ".MAIN_DB_PREFIX."mailing m ON m.rowid = s.fk_mailing";
+$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."sarbacane as s ON s.sarbacane_id = scc.sarbacane_campaignid";
+$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."mailing m ON m.rowid = s.fk_mailing";
 $sql.= " WHERE scc.fk_contact = ".$id;
 // Todo ajouter les filtres
 

--- a/contact_tab.php
+++ b/contact_tab.php
@@ -150,8 +150,8 @@ dol_fiche_end();
 $sql = "SELECT";
 $sql.= " m.titre, s.fk_mailing, scc.sarbacane_campaignid, scc.statut, scc.nb_open, scc.nb_click, scc.unsubscribe, scc.unsubscribed_email, scc.used_blacklist";
 $sql.= " FROM ".MAIN_DB_PREFIX.DolSarbacane::$campaign_contact_table." as scc";
-$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."sarbacane as s ON s.sarbacane_id = scc.sarbacane_campaignid";
-$sql.= " LEFT JOIN ".MAIN_DB_PREFIX."mailing m ON m.rowid = s.fk_mailing";
+$sql.= " JOIN ".MAIN_DB_PREFIX."sarbacane as s ON s.sarbacane_id = scc.sarbacane_campaignid";
+$sql.= " JOIN ".MAIN_DB_PREFIX."mailing m ON m.rowid = s.fk_mailing";
 $sql.= " WHERE scc.fk_contact = ".$id;
 // Todo ajouter les filtres
 

--- a/core/modules/modsarbacane.class.php
+++ b/core/modules/modsarbacane.class.php
@@ -60,7 +60,7 @@ class modsarbacane extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module sarbacane";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.6';
+		$this->version = '1.1.7';
 		// Key used in llx_const table to save module status enabled/disabled (where SARBACANE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/script/interface.php
+++ b/script/interface.php
@@ -113,6 +113,7 @@ switch ($set) {
 
 switch ($async_action) {
 	case 'export':
+
 		$result=$sarbacane->exportDesttoSarbacane($listid);
 		exit;
 		break;


### PR DESCRIPTION
Retour SGP : compatibilité du module sarbacane avec le module liste de distribution

Ici, je traite le bug qui concerne l'export des contacts dans sarbacane. En effet, lorsque les destinataires de la campagnes avaient comme origine une liste de distribution ou un fichier, toutes les informations n'étaient pas prises en compte. 

Note : je récupère le fk_contact au lieu du source_id pour que ce soit le plus générique possible (par ex si source liste de distribution le source id ne sera pas le contact)