### PR TITLE
Main ret sgp maj stat campaign statut

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Version 1.1 (2021-06-09)
 =====================
+- FIX Mise à jour des statistique = Mise à jour du statut du mailing dolibarr *2021-06-23* - 1.1.8
 - FIX Distribution List Compatibility *2021-06-22* - 1.1.7
 - FIX delete sarbacane campaign and stats when mailing is deleting *2021-06-17* - 1.1.6
 - FIX Set blacklist_id by "DEFAULT_BLACKLIST" when it is empty *2021-06-16* - 1.1.5

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -771,6 +771,8 @@ class DolSarbacane extends CommonObject {
 		if (!empty($TCampaignId))
 		{
 
+			$countnosend = 0;	//on compte le nombre de destinataire pour qui l'envoi du mailing a échoué, si il y en a au moins 1, le statut de la campagne passe en "envoyée partiellement"
+
 			foreach ($TCampaignId as $sarbacaneCampaignId)
 			{
 				try {
@@ -833,15 +835,16 @@ class DolSarbacane extends CommonObject {
 									$this->errors = $this->db->lastqueryerror();
 									$error++;
 								}
+							} else {
+								$countnosend ++;
 							}
 
 						}
 					}
 
 					if($res2 > 0 && !empty($this->CampaignStats)){
-
 						foreach($this->CampaignStats as $campaignStat){
-							$sql="UPDATE ".MAIN_DB_PREFIX."mailing SET date_envoi = '".dol_print_date($campaignStat['date'], '%Y-%m-%d %H:%M:%S')."' WHERE rowid=".((int)$sarbacaneCampaign_fkmailing);
+							$sql="UPDATE ".MAIN_DB_PREFIX."mailing SET date_envoi = '".dol_print_date($campaignStat['date'], '%Y-%m-%d %H:%M:%S')."', statut ='" .((empty($countnosend)) ? '3' : '2'). "'WHERE rowid=".((int)$sarbacaneCampaign_fkmailing);
 							$resql = $this->db->query($sql);
 
 							if(!$resql) {

--- a/core/modules/modsarbacane.class.php
+++ b/core/modules/modsarbacane.class.php
@@ -60,7 +60,7 @@ class modsarbacane extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module sarbacane";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.7';
+		$this->version = '1.1.8';
 		// Key used in llx_const table to save module status enabled/disabled (where SARBACANE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
Lors que l'on met à jour les statistiques de la campagne, on met à jour aussi le statut du mailing dolibarr associé à la campagne sarbacane : 
- Si le mailing a été envoyé à tous les expéditeurs alors on donne le statut "envoyé complètement"
- - Si le mailing n'est pas envoyé à tous les expéditeurs on donne le statut "envoyé partiellement"