### PR TITLE
contact_tab.php : liste des campagnes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Version 1.1 (2021-06-09)
 =====================
+- FIX contact_tab.php : on n'affiche que les campagnes au statut "envoyé " et "envoyé partiellement" *2021-06-25* - 1.1.12
 - FIX contact_tab.php fatal error *2021-06-25* - 1.1.11
 - FIX missing try catch *2021-06-24* - 1.1.10
 - FIX Mailing Delete Error Management *2021-06-24* - 1.1.9

--- a/contact_tab.php
+++ b/contact_tab.php
@@ -153,6 +153,7 @@ $sql.= " FROM ".MAIN_DB_PREFIX.DolSarbacane::$campaign_contact_table." as scc";
 $sql.= " JOIN ".MAIN_DB_PREFIX."sarbacane as s ON s.sarbacane_id = scc.sarbacane_campaignid";
 $sql.= " JOIN ".MAIN_DB_PREFIX."mailing m ON m.rowid = s.fk_mailing";
 $sql.= " WHERE scc.fk_contact = ".$id;
+$sql.= " AND m.statut IN(2,3)";
 // Todo ajouter les filtres
 
 if (isset($search_campaign) && !empty($search_campaign)) $sql.= " AND m.titre LIKE '%".$db->escape($search_campaign)."%'";

--- a/core/modules/modsarbacane.class.php
+++ b/core/modules/modsarbacane.class.php
@@ -60,7 +60,7 @@ class modsarbacane extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module sarbacane";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.11';
+		$this->version = '1.1.12';
 		// Key used in llx_const table to save module status enabled/disabled (where SARBACANE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
On n'affiche que les campagnes au statut "Envoyé complètement" ou au statut "Envoyé partiellement" sur l'onglet "Sarbacane" de la fiche des contacts