### PR TITLE
Main ret sgp stats status campaign npai

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Version 1.1 (2021-06-09)
 =====================
+- FIX Mise à jour des statistiques : si npai, alors la campagne doit être envoyé partiellement *2021-06-30* - 1.1.13
 - FIX contact_tab.php : on n'affiche que les campagnes au statut "envoyé " et "envoyé partiellement" *2021-06-25* - 1.1.12
 - FIX contact_tab.php fatal error *2021-06-25* - 1.1.11
 - FIX missing try catch *2021-06-24* - 1.1.10

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -782,7 +782,7 @@ class DolSarbacane extends CommonObject {
 		if (!empty($TCampaignId))
 		{
 
-			$countnosend = false;	//on compte le nombre de destinataire pour qui l'envoi du mailing a échoué, si il y en a au moins 1, le statut de la campagne passe en "envoyée partiellement"
+			$nosendcomplet = false;	//on compte le nombre de destinataire pour qui l'envoi du mailing a échoué, si il y en a au moins 1, le statut de la campagne passe en "envoyée partiellement"
 
 			foreach ($TCampaignId as $sarbacaneCampaignId)
 			{
@@ -827,6 +827,11 @@ class DolSarbacane extends CommonObject {
 								{
 									if (!empty($campaignContact->npai))
 									{
+										//si npai alors màj statut du destinataire au statut "non envoyé"
+										$sql = "UPDATE " . MAIN_DB_PREFIX . "mailing_cibles SET statut = 0 WHERE email ='" . $campaignStat['recipient']['email'] . "' AND fk_mailing =" . ((int)$sarbacaneCampaign_fkmailing);
+										$this->db->query($sql);
+										$nosendcomplet = true;
+
 										$campaignContact->fetch_contact($campaignContact->fk_contact);
 										if ($campaignContact->npai == $campaignContact->contact->email)
 										{
@@ -837,9 +842,9 @@ class DolSarbacane extends CommonObject {
 								}
 							}
 
+							//si success alors màj du statut "envoyé"
 							if ($campaignStat['success'] == true) {
 								$sql = "UPDATE " . MAIN_DB_PREFIX . "mailing_cibles SET statut = 1 WHERE email ='" . $campaignStat['recipient']['email'] . "' AND fk_mailing =" . ((int)$sarbacaneCampaign_fkmailing);
-
 								$this->db->query($sql);
 
 								if (!$resql) {
@@ -847,18 +852,16 @@ class DolSarbacane extends CommonObject {
 									$error++;
 								}
 							} else {
-								$countnosend = true;
+								$nosendcomplet = true;
 							}
 
 						}
-
 					}
 
 					if($res2 > 0 && !empty($this->CampaignStats)){
 
 						//on vérifie que le nombre de destinataires du mailing est bien égal au nombre de destinataires de la campagne Sarbacane
-						//si ce n'est pas le cas, cela veut dire qu'il y a eu un NPAI et on ne peut donc pas considérer la campagne comme envoyée complètement
-
+						//si ce n'est pas le cas, cela veut dire qu'une ou plusieurs adresses mails ont été exclues de l'envoie sur sarbacane (npai identifiée) et on ne peut donc pas considérer la campagne comme envoyée complètement
 						$sql = "SELECT COUNT(rowid) as nbDest FROM " . MAIN_DB_PREFIX . "mailing_cibles WHERE fk_mailing =" . ((int)$sarbacaneCampaign_fkmailing);
 						$resql = $this->db->query($sql);
 
@@ -866,16 +869,17 @@ class DolSarbacane extends CommonObject {
 							$obj = $this->db->fetch_object($resql);
 
 							if ($obj->nbDest > count($this->CampaignRecipientStats)) {
-								$countnosend = true;
+								$nosendcomplet = true;
 							}
 						} else {
 							$this->errors = $this->db->lastqueryerror();
 							$error++;
 						}
 
+						//màj du statut de la campagne : si $nosendcomplet est à true, c'est envoyé partiellement
 						foreach ($this->CampaignStats as $campaignStat) {
 
-							$sql = "UPDATE " . MAIN_DB_PREFIX . "mailing SET date_envoi = '" . dol_print_date($campaignStat['date'], '%Y-%m-%d %H:%M:%S') . "', statut ='" . ((empty($countnosend)) ? '3' : '2') . "'WHERE rowid=" . ((int)$sarbacaneCampaign_fkmailing);
+							$sql = "UPDATE " . MAIN_DB_PREFIX . "mailing SET date_envoi = '" . dol_print_date($campaignStat['date'], '%Y-%m-%d %H:%M:%S') . "', statut ='" . (($nosendcomplet == false) ? '3' : '2') . "'WHERE rowid=" . ((int)$sarbacaneCampaign_fkmailing);
 							$resql = $this->db->query($sql);
 
 							if (!$resql) {

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -830,7 +830,6 @@ class DolSarbacane extends CommonObject {
 										//si npai alors màj statut du destinataire au statut "non envoyé"
 										$sql = "UPDATE " . MAIN_DB_PREFIX . "mailing_cibles SET statut = 0 WHERE email ='" . $campaignStat['recipient']['email'] . "' AND fk_mailing =" . ((int)$sarbacaneCampaign_fkmailing);
 										$this->db->query($sql);
-										$nosendcomplet = true;
 
 										$campaignContact->fetch_contact($campaignContact->fk_contact);
 										if ($campaignContact->npai == $campaignContact->contact->email)
@@ -842,7 +841,7 @@ class DolSarbacane extends CommonObject {
 								}
 							}
 
-							//si success alors màj du statut "envoyé"
+							//si success alors màj du statut "envoyé" sinon on note que la campagne n'a pas été envoyé complètement
 							if ($campaignStat['success'] == true) {
 								$sql = "UPDATE " . MAIN_DB_PREFIX . "mailing_cibles SET statut = 1 WHERE email ='" . $campaignStat['recipient']['email'] . "' AND fk_mailing =" . ((int)$sarbacaneCampaign_fkmailing);
 								$this->db->query($sql);
@@ -854,7 +853,6 @@ class DolSarbacane extends CommonObject {
 							} else {
 								$nosendcomplet = true;
 							}
-
 						}
 					}
 

--- a/core/modules/modsarbacane.class.php
+++ b/core/modules/modsarbacane.class.php
@@ -60,7 +60,7 @@ class modsarbacane extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module sarbacane";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.12';
+		$this->version = '1.1.13';
 		// Key used in llx_const table to save module status enabled/disabled (where SARBACANE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
Deux fix : 

- lorsqu'il y a un npai non détecté au préalable par sarbacane (un envoi rejeté), il faut passer le statut du destinataire du mailing en "non envoyée"
- lorsqu'il y a un npai détecté au préalable par sarbacane (exclu de la campagne), il faut passer le statut du mailing à "envoyé partiellement"