### PR TITLE
PULLUP (main) | FIX :  Add output to update stats cron

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 
 Version 1.1 (2021-06-09)
 =====================
-- FIX : Ajout d'output lors de lexecution du CRON (en cas d'erreur / en cas de succès pour l'execution time) *31/08/2021* - 1.1.23
-- FIX : Mise à jour des stats : toujours renseigner "used_blacklist" *24/08/2021* - 1.1.22
+- FIX : Mise à jour des stats : toujours renseigner "used_blacklist" *24/08/2021* - 1.1.23
+- FIX : Ajout d'output lors de lexecution du CRON (en cas d'erreur / en cas de succès pour l'execution time) *31/08/2021* - 1.1.22
 - FIX : Récupération de l'ID de la blacklist de la campagne *17/08/2021* - 1.1.21
 - FIX : Lorsque l'on ajoute des destinataires à une campagne Sarbacane via une liste de diffusion Dolibarr, les destinataires n'étaient pas inscrits en BDD *16/08/2021* - 1.1.20
 - FIX : La liste de désinscription liée à la campagne n'est plus systématiquement renseignée avec la liste par défaut mais doit forcément être renseignée manuellement pour pouvoir créer la campagne Sarbacane *26/07/2021* - 1.1.19

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Version 1.1 (2021-06-09)
 =====================
-- FIX : Ajout d'output lors de lexecution du CRON (en cas d'erreur / en cas de succès pour l'execution time)
+- FIX : Ajout d'output lors de lexecution du CRON (en cas d'erreur / en cas de succès pour l'execution time) *31/08/2021* - 1.1.23
 - FIX : Mise à jour des stats : toujours renseigner "used_blacklist" *24/08/2021* - 1.1.22
 - FIX : Récupération de l'ID de la blacklist de la campagne *17/08/2021* - 1.1.21
 - FIX : Lorsque l'on ajoute des destinataires à une campagne Sarbacane via une liste de diffusion Dolibarr, les destinataires n'étaient pas inscrits en BDD *16/08/2021* - 1.1.20

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Version 1.1 (2021-06-09)
 =====================
+- FIX : Ajout d'output lors de lexecution du CRON (en cas d'erreur / en cas de succès pour l'execution time)
 - FIX : Récupération de l'ID de la blacklist de la campagne *17/08/2021* - 1.1.21
 - FIX : Lorsque l'on ajoute des destinataires à une campagne Sarbacane via une liste de diffusion Dolibarr, les destinataires n'étaient pas inscrits en BDD *16/08/2021* - 1.1.20
 - FIX : La liste de désinscription liée à la campagne n'est plus systématiquement renseignée avec la liste par défaut mais doit forcément être renseignée manuellement pour pouvoir créer la campagne Sarbacane *26/07/2021* - 1.1.19

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -914,7 +914,21 @@ class DolSarbacane extends CommonObject {
 	 */
 	public function CRONupdateCampaignRecipientStats()
 	{
-		$ret = $this->updateCampaignRecipientStats();
+		$a = microtime(true);
+
+		$this->output = '';
+		try {
+			$ret = $this->updateCampaignRecipientStats();
+		}
+		catch(Exception $e) {
+			//dol_syslog();
+			$this->output .= '...';
+			return 1;	// Error
+		}
+
+		$b = microtime(true);
+		$this->output .= 'Execution time: '.($b-$a);
+
 		if ($ret > 0) return 0;
 		else return 1;
 	}

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -922,7 +922,7 @@ class DolSarbacane extends CommonObject {
 		}
 		catch(Exception $e) {
 			//dol_syslog();
-			$this->output .= '...';
+			$this->output .= 'CRON exécution has stopped because of an error';
 			return 1;	// Error
 		}
 

--- a/core/modules/modsarbacane.class.php
+++ b/core/modules/modsarbacane.class.php
@@ -60,7 +60,7 @@ class modsarbacane extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module sarbacane";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.21';
+		$this->version = '1.1.22';
 		// Key used in llx_const table to save module status enabled/disabled (where SARBACANE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/core/modules/modsarbacane.class.php
+++ b/core/modules/modsarbacane.class.php
@@ -60,7 +60,7 @@ class modsarbacane extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module sarbacane";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.22';
+		$this->version = '1.1.23';
 		// Key used in llx_const table to save module status enabled/disabled (where SARBACANE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
### PULLUP (main) | FIX : Add output to CRONupdateCampaignRecipientStats

- Add an output for execution error : "CRON exécution has stopped because of an error"
- Add an output for execution success : "Execution time: ..."