### PR TITLE
FIX : Ajout de paramètres pour appel API

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Version 1.1 (2021-06-09)
 =====================
+- FIX : Ajout de paramètres (offset et limit) dans l'appel API destiné à lister tous les contacts d'une liste de contacts *15/09/2021* - 1.1.24
 - FIX : Mise à jour des stats : toujours renseigner "used_blacklist" *24/08/2021* - 1.1.23
 - FIX : Ajout d'output lors de lexecution du CRON (en cas d'erreur / en cas de succès pour l'execution time) *31/08/2021* - 1.1.22
 - FIX : Récupération de l'ID de la blacklist de la campagne *17/08/2021* - 1.1.21

--- a/class/dolsarbacane.class.php
+++ b/class/dolsarbacane.class.php
@@ -668,15 +668,27 @@ class DolSarbacane extends CommonObject {
         $this->getInstanceSarbacane();
         $error = 0;
 
+		$offset =0;
         $this->email_lines = array();
-        try {
-            $this->email_lines = $this->sarbacane->get('lists/'.$this->sarbacane_listid.'/contacts', array());
-        }
-        catch(Exception $e) {
-            $this->error = $e->getMessage();
-            dol_syslog(get_class($this)."::createSarbacaneCampaign ".$this->error, LOG_ERR);
-            return -1;
-        }
+		while (1) {
+			try {
+				$email_lines = $this->sarbacane->get('lists/'.$this->sarbacane_listid.'/contacts?offset=' . $offset .'&limit=1000', array());
+				$this->email_lines = array_merge($this->email_lines, $email_lines);
+				if (count($email_lines) < 1000) {
+					break;
+				} else {
+					$offset += 1000;
+					continue;
+				}
+			}
+			catch(Exception $e) {
+				$this->error = $e->getMessage();
+				dol_syslog(get_class($this)."::createSarbacaneCampaign ".$this->error, LOG_ERR);
+				return -1;
+			}
+		}
+
+
         if(empty($this->email_lines['message'])) {
             $emailsegment = 1;
         }

--- a/core/modules/modsarbacane.class.php
+++ b/core/modules/modsarbacane.class.php
@@ -60,7 +60,7 @@ class modsarbacane extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module sarbacane";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.23';
+		$this->version = '1.1.24';
 		// Key used in llx_const table to save module status enabled/disabled (where SARBACANE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
### FIX : Ajout de paramètres pour appel API

La limite des retours pour les appels à l'API sarbacane est de 1000. Or certaines liste de contacts sont composés de plus de 1000 contacts. 
De plus, lors qu’aucun paramètre n'est renseigné à l'appel API, on ne peut être sur que la totalité des informations demandées seront retournées.

- Ajout d'une boucle permettant, si l'on atteint le nombre de retour max, de réitérer l'appel API
- Ajout d'un paramètre "limit=" permettant de s'assurer d'obtenir le nombre maximal de retours lors de chaque appel
- Ajout d'un paramètre "offset" permettant de parcourir les listes de contacts de 1000 en 1000 afin de retourner, à travers tous les appels, la totalités des informations/contacts souhaités 